### PR TITLE
Disable EGL backend for wxGLCanvas

### DIFF
--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -92,6 +92,7 @@ vcpkg_cmake_configure(
         -DwxUSE_LIBTIFF=sys
         -DwxUSE_NANOSVG=sys
         -DwxUSE_GLCANVAS=ON
+        -DwxUSE_GLCANVAS_EGL=OFF
         -DwxUSE_LIBGNOMEVFS=OFF
         -DwxUSE_LIBNOTIFY=OFF
         -DwxUSE_SECRETSTORE=OFF


### PR DESCRIPTION
Disable EGL backend for wxGLCanvas to make it possible to get the current GL context and display using GLX on Linux. This issue is described here: https://forums.wxwidgets.org/viewtopic.php?f=1&t=50203