### PR TITLE
Enabled cleaning program cache

### DIFF
--- a/ports/boost-compute/clean-program-cache.patch
+++ b/ports/boost-compute/clean-program-cache.patch
@@ -1,0 +1,23 @@
+diff --git a/include/boost/compute/utility/program_cache.hpp b/include/boost/compute/utility/program_cache.hpp
+index c80e1a3..9a70aa1 100644
+--- a/include/boost/compute/utility/program_cache.hpp
++++ b/include/boost/compute/utility/program_cache.hpp
+@@ -146,12 +146,17 @@ public:
+     /// program objects used by its algorithms. All Boost.Compute programs are
+     /// stored with a cache key beginning with \c "__boost". User programs
+     /// should avoid using the same prefix in order to prevent collisions.
+-    static boost::shared_ptr<program_cache> get_global_cache(const context &context)
++    static boost::shared_ptr<program_cache> get_global_cache(const context &context, bool clear = false)
+     {
+         typedef detail::lru_cache<cl_context, boost::shared_ptr<program_cache> > cache_map;
+ 
+         BOOST_COMPUTE_DETAIL_GLOBAL_STATIC(cache_map, caches, (8));
+ 
++		if (clear) {
++			caches.clear();
++			return nullptr;
++		}
++
+         boost::optional<boost::shared_ptr<program_cache> > cache = caches.get(context.get());
+         if(!cache){
+             cache = boost::make_shared<program_cache>(64);

--- a/ports/boost-compute/portfile.cmake
+++ b/ports/boost-compute/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF boost-1.83.0
     SHA512 bb555cffc7761a1dba3b010aa45782af22d4bac049ecfa9d26695a5eb3c5722b29f5f7b30143d17698b2098f81dcc7eaef2425482c5a6495e29324b1f8f324b2
     HEAD_REF master
+    PATCHES
+        clean-program-cache.patch
 )
 
 include(${CURRENT_INSTALLED_DIR}/share/boost-vcpkg-helpers/boost-modular-headers.cmake)

--- a/ports/liblas/portfile.cmake
+++ b/ports/liblas/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
         -DBUILD_OSGEO4W=OFF
         -DWITH_TESTS=OFF
+        -DWITH_GDAL=ON
     OPTIONS_DEBUG
         -DWITH_UTILITIES=OFF
 )

--- a/ports/liblas/vcpkg.json
+++ b/ports/liblas/vcpkg.json
@@ -13,6 +13,7 @@
     "boost-program-options",
     "boost-property-tree",
     "boost-uuid",
+    "gdal",
     "libgeotiff",
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
- Enabled cleaning program cache
- Also force liblas to compile with GDAL (I hope?)

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
