### PR TITLE
Cast from const in clFFT

### DIFF
--- a/ports/clfft/const-cast.patch
+++ b/ports/clfft/const-cast.patch
@@ -1,0 +1,22 @@
+diff --git a/src/library/generator.stockham.cpp b/src/library/generator.stockham.cpp
+index f100c11..9f78b2b 100644
+--- a/src/library/generator.stockham.cpp
++++ b/src/library/generator.stockham.cpp
+@@ -3885,7 +3885,7 @@ namespace StockhamGenerator
+ 							if(inInterleaved || inReal)
+ 							{
+ 								if(!rcSimple) {	str += "lwbIn2 = gbIn + iOffset2;\n\t"; }
+-								str += "lwbIn = gbIn + iOffset;\n\t"; 
++								str += "lwbIn = (__global float2 *)gbIn + iOffset;\n\t"; 
+ 							}
+ 							else
+ 							{
+@@ -3961,7 +3961,7 @@ namespace StockhamGenerator
+ 						{
+ 							if(inInterleaved)
+ 							{
+-								str += "lwbIn = gbIn + iOffset;\n\t";
++								str += "lwbIn = (__global float2 *)gbIn + iOffset;\n\t";
+ 							}
+ 							else
+ 							{

--- a/ports/clfft/portfile.cmake
+++ b/ports/clfft/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         tweak-install.patch
         fix-build.patch
+		const-cast.patch
 )
 
 SET(GCC_PERMISSIVE_FLAGS "-fpermissive")


### PR DESCRIPTION
Added a cast which removes the const from clfft kernel because it does not compile on my computer otherwise (and probably a lot of other computers)