### PR TITLE
Removed program_options from liblas

### DIFF
--- a/ports/liblas/remove_unnecessary_boost_dependency.diff
+++ b/ports/liblas/remove_unnecessary_boost_dependency.diff
@@ -7,7 +7,7 @@ index d246a88d..634157c0 100644
  
  find_package(Threads)
 -find_package(Boost 1.42 COMPONENTS program_options thread system iostreams filesystem REQUIRED)
-+find_package(Boost 1.42 COMPONENTS iostreams program_options serialization thread REQUIRED)
++find_package(Boost 1.42 COMPONENTS iostreams serialization thread REQUIRED)
 + 
 +# The following header-only and their dependencies are additionally required,
 +# but cannot be explicitly requested via find_package, so make sure they exists:


### PR DESCRIPTION
Package will not be found and we do not seem to use it.