### PR TITLE
Do not add m64 flag on Linux

### DIFF
--- a/ports/clfft/no-m64-linux.patch
+++ b/ports/clfft/no-m64-linux.patch
@@ -1,0 +1,19 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index ee2600b..5b51a76 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -219,9 +219,11 @@ elseif( CMAKE_COMPILER_IS_GNUCXX )
+ 		add_definitions( "/D_DEBUG" )
+ 	endif( )
+ 
+-	if( BUILD64 )
+-		set( CMAKE_CXX_FLAGS "-m64 ${CMAKE_CXX_FLAGS}" )
+-		set( CMAKE_C_FLAGS "-m64 ${CMAKE_C_FLAGS}" )
++	if(BUILD64)
++		if(WIN32)
++			set( CMAKE_CXX_FLAGS "-m64 ${CMAKE_CXX_FLAGS}" )
++			set( CMAKE_C_FLAGS "-m64 ${CMAKE_C_FLAGS}" )
++		endif()
+ 	else( )
+ 		set( CMAKE_CXX_FLAGS "-m32 ${CMAKE_CXX_FLAGS}" )
+ 		set( CMAKE_C_FLAGS "-m32 ${CMAKE_C_FLAGS}" )

--- a/ports/clfft/portfile.cmake
+++ b/ports/clfft/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         tweak-install.patch
         fix-build.patch
 		const-cast.patch
+		no-m64-linux.patch
 )
 
 SET(GCC_PERMISSIVE_FLAGS "-fpermissive")


### PR DESCRIPTION
m64 flag not available on Linux